### PR TITLE
Circleci project setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ jobs:
           name: Check files
           command: ls
       - run:
-          name: Cd Into Client Folder
-          command: cd client
-      - run:
           name: Install Dependencies
           command: cd client && npm install
       - run:


### PR DESCRIPTION
Adds circle ci to repo, runs the test in the client folder, and verifies a deploy for heroku. 